### PR TITLE
allow torch 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-torch = "^1.6.0"
+torch = ">=1.6.0,<2.1.0"
 scikit-learn = "*"
 matplotlib = "*"
 opencv-python = "*"


### PR DESCRIPTION
Given Pytorch 2.0 is backwards compatible, allowing it shouldn't break anything (Famous last words). I'm keeping 2.1.0 as the upper limit.